### PR TITLE
[TEST] 파일 테스트 - 로컬

### DIFF
--- a/src/test/java/com/hanyang/arttherapy/service/LocalFileStorageServiceTest.java
+++ b/src/test/java/com/hanyang/arttherapy/service/LocalFileStorageServiceTest.java
@@ -1,0 +1,53 @@
+package com.hanyang.arttherapy.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.*;
+import java.util.*;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.hanyang.arttherapy.domain.enums.*;
+import com.hanyang.arttherapy.dto.response.*;
+import com.hanyang.arttherapy.repository.*;
+
+@SpringBootTest
+class LocalFileStorageServiceTest {
+
+  @Autowired private LocalFileStorageService localFileStorageService;
+  @Autowired private FileStorageService fileStorageService;
+  @Autowired private FileStorageUtils fileUtils;
+  @Autowired FilesRepository fileRepository;
+
+  private MultipartFile multipartFile;
+
+  @BeforeEach
+  void init() {
+    multipartFile =
+        new MockMultipartFile("file", "image.jpg", "image/jpeg", "test content".getBytes());
+  }
+
+  @Test
+  void storeValidFiles() {
+
+    FilesType fileType = FilesType.ART;
+
+    FileResponseListDto result = fileStorageService.store(List.of(multipartFile), fileType);
+
+    FileResponseDto storedFile = result.files().get(0);
+
+    assertThat(storedFile).isNotNull();
+    assertThat(storedFile.url()).contains("art");
+    assertThat(storedFile.name()).isNotNull();
+    assertThat(storedFile.extension()).isEqualTo("jpg");
+    assertThat(storedFile.url()).contains(storedFile.name());
+
+    File savedFile = new File(storedFile.url());
+    assertThat(savedFile).exists();
+    assertThat(savedFile.isFile()).isTrue();
+  }
+}

--- a/src/test/java/com/hanyang/arttherapy/service/LocalFileStorageServiceTest.java
+++ b/src/test/java/com/hanyang/arttherapy/service/LocalFileStorageServiceTest.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.hanyang.arttherapy.common.exception.CustomException;
+import com.hanyang.arttherapy.common.exception.exceptionType.FileSystemExceptionType;
 import com.hanyang.arttherapy.domain.enums.*;
 import com.hanyang.arttherapy.dto.response.*;
 import com.hanyang.arttherapy.repository.*;
@@ -49,5 +51,17 @@ class LocalFileStorageServiceTest {
     File savedFile = new File(storedFile.url());
     assertThat(savedFile).exists();
     assertThat(savedFile.isFile()).isTrue();
+  }
+
+  @Test
+  void invalidFileExtension() {
+    FilesType fileType = FilesType.ART;
+
+    MultipartFile invalidFile =
+        new MockMultipartFile("file", "invalid.mp4", "video/mp4", "test content".getBytes());
+
+    assertThatThrownBy(() -> fileStorageService.store(List.of(invalidFile), fileType))
+        .isInstanceOf(CustomException.class)
+        .hasMessageContaining(FileSystemExceptionType.INVALID_FILE_EXTENSION.getMessage());
   }
 }


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
- closed #14 
## :writing_hand: Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 파일 업로드 테스트
- 파일 확장자 검증 테스트
- 파일 소프트 삭제 테스트
## :white_check_mark: Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 테스트 결과 성공
![image](https://github.com/user-attachments/assets/ae127c90-1c1a-40df-a04b-3c0eb0768454)
- 파일 용량 유효성 검사의 경우 스프링의 기본 에러 처리가 먼저 실행되므로 Assertion으로 에러를 체크할 때 던져지지 않아 우선 보류