### PR TITLE
[FEAT]전시회 등록 기능 구현

### DIFF
--- a/src/main/java/com/hanyang/arttherapy/controller/GalleriesController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/GalleriesController.java
@@ -1,0 +1,24 @@
+package com.hanyang.arttherapy.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hanyang.arttherapy.domain.Galleries;
+import com.hanyang.arttherapy.service.GalleriesService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/galleries")
+public class GalleriesController {
+
+  private final GalleriesService galleriesService;
+
+  //  전시회 등록
+  @PostMapping
+  public ResponseEntity<Galleries> create(@RequestBody Galleries galleries) {
+    Galleries saved = galleriesService.save(galleries);
+    return ResponseEntity.status(201).body(saved);
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/domain/Galleries.java
+++ b/src/main/java/com/hanyang/arttherapy/domain/Galleries.java
@@ -1,0 +1,50 @@
+package com.hanyang.arttherapy.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "galleries")
+public class Galleries {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long galleriesNo;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false)
+  private LocalDateTime startDate;
+
+  @Column(nullable = false)
+  private LocalDateTime endDate;
+
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  // 생성자
+  public Galleries(String title, LocalDateTime startDate, LocalDateTime endDate) {
+    this.title = title;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+
+  // 수정용 메서드
+  public void update(String title, LocalDateTime startDate, LocalDateTime endDate) {
+    this.title = title;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/repository/GalleriesRepository.java
+++ b/src/main/java/com/hanyang/arttherapy/repository/GalleriesRepository.java
@@ -1,0 +1,9 @@
+package com.hanyang.arttherapy.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hanyang.arttherapy.domain.Galleries;
+
+@Repository
+public interface GalleriesRepository extends JpaRepository<Galleries, Long> {}

--- a/src/main/java/com/hanyang/arttherapy/service/GalleriesService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/GalleriesService.java
@@ -1,0 +1,20 @@
+package com.hanyang.arttherapy.service;
+
+import org.springframework.stereotype.Service;
+
+import com.hanyang.arttherapy.domain.Galleries;
+import com.hanyang.arttherapy.repository.GalleriesRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GalleriesService {
+
+  private final GalleriesRepository galleriesRepository;
+
+  // 전시회 등록
+  public Galleries save(Galleries galleries) {
+    return galleriesRepository.save(galleries);
+  }
+}


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
-Closes #29
## :writing_hand: Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 전시회 등록 기능 구현
- `GalleriesController`, `GalleriesService`, `GalleriesRepository`, `Galleries` 엔터티 생성

## :white_check_mark: Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- Postman을 통한 정상 등록 확인
- 필수값 누락 시 400 에러 반환됨