### PR TITLE
[FEAT] 전시회 수정 기능 구현

### DIFF
--- a/src/main/java/com/hanyang/arttherapy/controller/GalleriesController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/GalleriesController.java
@@ -1,0 +1,24 @@
+package com.hanyang.arttherapy.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hanyang.arttherapy.domain.Galleries;
+import com.hanyang.arttherapy.service.GalleriesService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/galleries")
+public class GalleriesController {
+
+  private final GalleriesService galleriesService;
+
+  //  전시회 등록
+  @PostMapping
+  public ResponseEntity<Galleries> create(@RequestBody Galleries galleries) {
+    Galleries saved = galleriesService.save(galleries);
+    return ResponseEntity.status(201).body(saved);
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/controller/GalleriesController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/GalleriesController.java
@@ -1,7 +1,5 @@
 package com.hanyang.arttherapy.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,17 +15,10 @@ public class GalleriesController {
 
   private final GalleriesService galleriesService;
 
-  //  전시회 전체 조회
-  @GetMapping
-  public ResponseEntity<List<Galleries>> getAllGalleries() {
-    List<Galleries> galleries = galleriesService.getAllGalleries();
-    return ResponseEntity.ok(galleries);
-  }
-
-  //  전시회 개별 조회
-  @GetMapping("/{id}")
-  public ResponseEntity<Galleries> getGalleryById(@PathVariable Long id) {
-    Galleries gallery = galleriesService.getGalleryById(id);
-    return ResponseEntity.ok(gallery);
+  //  전시회 수정
+  @PutMapping("/{id}")
+  public ResponseEntity<Galleries> update(@PathVariable Long id, @RequestBody Galleries updated) {
+    Galleries updatedGallery = galleriesService.update(id, updated);
+    return ResponseEntity.ok(updatedGallery);
   }
 }

--- a/src/main/java/com/hanyang/arttherapy/controller/GalleriesController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/GalleriesController.java
@@ -1,5 +1,7 @@
 package com.hanyang.arttherapy.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,10 +17,17 @@ public class GalleriesController {
 
   private final GalleriesService galleriesService;
 
-  //  전시회 등록
-  @PostMapping
-  public ResponseEntity<Galleries> create(@RequestBody Galleries galleries) {
-    Galleries saved = galleriesService.save(galleries);
-    return ResponseEntity.status(201).body(saved);
+  //  전시회 전체 조회
+  @GetMapping
+  public ResponseEntity<List<Galleries>> getAllGalleries() {
+    List<Galleries> galleries = galleriesService.getAllGalleries();
+    return ResponseEntity.ok(galleries);
+  }
+
+  //  전시회 개별 조회
+  @GetMapping("/{id}")
+  public ResponseEntity<Galleries> getGalleryById(@PathVariable Long id) {
+    Galleries gallery = galleriesService.getGalleryById(id);
+    return ResponseEntity.ok(gallery);
   }
 }

--- a/src/main/java/com/hanyang/arttherapy/domain/Galleries.java
+++ b/src/main/java/com/hanyang/arttherapy/domain/Galleries.java
@@ -1,0 +1,50 @@
+package com.hanyang.arttherapy.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "galleries")
+public class Galleries {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long galleriesNo;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false)
+  private LocalDateTime startDate;
+
+  @Column(nullable = false)
+  private LocalDateTime endDate;
+
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  // 생성자
+  public Galleries(String title, LocalDateTime startDate, LocalDateTime endDate) {
+    this.title = title;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+
+  // 수정용 메서드
+  public void update(String title, LocalDateTime startDate, LocalDateTime endDate) {
+    this.title = title;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/repository/GalleriesRepository.java
+++ b/src/main/java/com/hanyang/arttherapy/repository/GalleriesRepository.java
@@ -1,0 +1,9 @@
+package com.hanyang.arttherapy.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hanyang.arttherapy.domain.Galleries;
+
+@Repository
+public interface GalleriesRepository extends JpaRepository<Galleries, Long> {}

--- a/src/main/java/com/hanyang/arttherapy/service/GalleriesService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/GalleriesService.java
@@ -1,5 +1,7 @@
 package com.hanyang.arttherapy.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.hanyang.arttherapy.domain.Galleries;
@@ -13,8 +15,15 @@ public class GalleriesService {
 
   private final GalleriesRepository galleriesRepository;
 
-  // 전시회 등록
-  public Galleries save(Galleries galleries) {
-    return galleriesRepository.save(galleries);
+  // 전시회 전체 조회
+  public List<Galleries> getAllGalleries() {
+    return galleriesRepository.findAll();
+  }
+
+  // 전시회 상세 조회
+  public Galleries getGalleryById(Long id) {
+    return galleriesRepository
+        .findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 전시회가 존재하지 않습니다."));
   }
 }

--- a/src/main/java/com/hanyang/arttherapy/service/GalleriesService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/GalleriesService.java
@@ -1,0 +1,20 @@
+package com.hanyang.arttherapy.service;
+
+import org.springframework.stereotype.Service;
+
+import com.hanyang.arttherapy.domain.Galleries;
+import com.hanyang.arttherapy.repository.GalleriesRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GalleriesService {
+
+  private final GalleriesRepository galleriesRepository;
+
+  // 전시회 등록
+  public Galleries save(Galleries galleries) {
+    return galleriesRepository.save(galleries);
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/service/GalleriesService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/GalleriesService.java
@@ -1,7 +1,5 @@
 package com.hanyang.arttherapy.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 
 import com.hanyang.arttherapy.domain.Galleries;
@@ -15,15 +13,10 @@ public class GalleriesService {
 
   private final GalleriesRepository galleriesRepository;
 
-  // 전시회 전체 조회
-  public List<Galleries> getAllGalleries() {
-    return galleriesRepository.findAll();
-  }
-
-  // 전시회 상세 조회
-  public Galleries getGalleryById(Long id) {
-    return galleriesRepository
-        .findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("해당 전시회가 존재하지 않습니다."));
+  // 전시회 수정
+  public Galleries update(Long id, Galleries updated) {
+    Galleries gallery = getGalleryById(id);
+    gallery.update(updated.getTitle(), updated.getStartDate(), updated.getEndDate());
+    return galleriesRepository.save(gallery);
   }
 }


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
Closes #36
## :writing_hand: Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 전시회 수정 API 기능 구현
- `@PutMapping`을 통한 ID 기반 수정 처리
- 서비스 로직에서 `getGalleryById()` 호출 후 갤러리 정보 갱신
## :white_check_mark: Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- `getGalleryById()`는 이전 브랜치(#34)에서 구현되어 있음