### PR TITLE
[FEAT] 파일 삭제 - S3

### DIFF
--- a/src/main/java/com/hanyang/arttherapy/controller/ArtistController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/ArtistController.java
@@ -42,6 +42,6 @@ public class ArtistController {
   @DeleteMapping("/{artistsNo}")
   public ResponseEntity<Void> deleteArtist(@PathVariable Long artistsNo) {
     artistsService.deleteAritst(artistsNo);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/hanyang/arttherapy/controller/FileController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/FileController.java
@@ -29,6 +29,6 @@ public class FileController {
   @DeleteMapping("/{filesNo}")
   public ResponseEntity<Void> softDelete(@PathVariable Long filesNo) {
     fileStorageService.softDeleteFile(filesNo);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/hanyang/arttherapy/service/FileScheduledService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/FileScheduledService.java
@@ -23,7 +23,7 @@ public class FileScheduledService {
 
   private static final int FILE_EXPIRATION_DAYS = 5;
 
-  @Scheduled(cron = "0 0 0 * * ?")
+  @Scheduled(cron = "0 0 3 ? * SUN")
   public void deleteFile() {
     LocalDateTime cutoffDate = getCutoffDate(FILE_EXPIRATION_DAYS);
 
@@ -48,8 +48,19 @@ public class FileScheduledService {
   }
 
   private void deleteFileFromSystem(Files files) {
-    fileStorageService.deletedFileFromSystem(files);
-    filesRepository.delete(files);
+    try {
+      if (isFileExist(files.getFilesNo())) {
+        fileStorageService.deletedFileFromSystem(files.getFilesNo());
+        filesRepository.delete(files);
+      }
+    } catch (Exception e) {
+      log.error("파일 삭제 실패, 파일 번호: {}, 오류: {}", files.getFilesNo(), e.getMessage(), e);
+    }
+  }
+
+  private boolean isFileExist(Long filesNo) {
+    Optional<Files> fileOptional = filesRepository.findById(filesNo);
+    return fileOptional.isPresent();
   }
 
   private LocalDateTime getCutoffDate(int days) {

--- a/src/main/java/com/hanyang/arttherapy/service/FileStorageService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/FileStorageService.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import com.hanyang.arttherapy.domain.Files;
 import com.hanyang.arttherapy.domain.enums.*;
 import com.hanyang.arttherapy.dto.response.*;
 
@@ -13,5 +12,5 @@ public interface FileStorageService {
 
   void softDeleteFile(Long filesNo);
 
-  void deletedFileFromSystem(Files file);
+  void deletedFileFromSystem(Long filesNo);
 }

--- a/src/main/java/com/hanyang/arttherapy/service/LocalFileStorageService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/LocalFileStorageService.java
@@ -59,7 +59,8 @@ public class LocalFileStorageService implements FileStorageService {
   }
 
   @Override
-  public void deletedFileFromSystem(Files file) {
+  public void deletedFileFromSystem(Long filesNo) {
+    Files file = getFileById(filesNo);
     File fileToDelete = new File(file.getUrl());
     boolean deleted = fileToDelete.delete();
     if (!deleted) {

--- a/src/main/java/com/hanyang/arttherapy/service/LocalFileStorageService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/LocalFileStorageService.java
@@ -70,7 +70,7 @@ public class LocalFileStorageService implements FileStorageService {
 
   private Files getFileById(Long filesNo) {
     return filesRepository
-        .findByFilesNoAndUseYn(filesNo, true)
+        .findById(filesNo)
         .orElseThrow(() -> new CustomException(FileSystemExceptionType.FILE_NOT_FOUND));
   }
 


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
- closed #53 
## :writing_hand: Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- S3 파일 삭제 기능 구현
- 소프트 삭제, 스케줄러 실제 삭제 리팩토링
- 삭제 시 HTTP 응답 204 변경
## :white_check_mark: Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- Postman 성공
![화면 캡처 2025-05-11 235903](https://github.com/user-attachments/assets/bf69ce00-f0d6-462f-bd97-b6e70827888e)
- S3 삭제 성공 (`createAt`, `useYn`, `delYn` 조건 여부 걸리는지 체크 완료)
- 삭제 전
![image](https://github.com/user-attachments/assets/56b8b626-4bdc-4a90-a034-5184e6db5ce9)
- 삭제 후
![image](https://github.com/user-attachments/assets/4b87583a-414c-4cd2-a23c-893690c22dac)
