### PR TITLE
[FEAT] 연도, 기수 필터링 목록 기능 및 공지 게시판 기능 추가

### DIFF
--- a/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/ArtsExceptionType.java
+++ b/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/ArtsExceptionType.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ArtsExceptionType implements ExceptionType {
   ART_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 작품을 찾을 수 없습니다."),
-  INVALID_ART_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 작품 요청입니다.");
+  INVALID_ART_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 작품 요청입니다."),
+  ART_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 작품을 불러오지 못했습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/NoticeException.java
+++ b/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/NoticeException.java
@@ -1,0 +1,31 @@
+package com.hanyang.arttherapy.common.exception.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+public enum NoticeException implements ExceptionType {
+  NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+  NOTICE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "공지사항 저장에 실패했습니다."),
+  NOTICE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "공지사항 수정에 실패했습니다."),
+  NOTICE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "공지사항 삭제에 실패했습니다."),
+  NOT_NOTICE_OWNER(HttpStatus.UNAUTHORIZED, "관리자만 수정할 수 있습니다."),
+  INVALID_NOTICE_REQUEST(HttpStatus.BAD_REQUEST, "공지사항 요청 형식이 잘못되었습니다."),
+  NOTICE_FILE_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "공지사항 첨부파일 조회에 실패했습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  NoticeException(HttpStatus status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus status() {
+    return status;
+  }
+
+  @Override
+  public String message() {
+    return message;
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/ReviewException.java
+++ b/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/ReviewException.java
@@ -5,12 +5,13 @@ import org.springframework.http.HttpStatus;
 public enum ReviewException implements ExceptionType {
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰입니다."),
   REVIEW_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "리뷰 저장에 실패했습니다."),
-  REVIEW_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "리뷰 수정에 실패했습니다."),
-  REVIEW_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "리뷰 삭제에 실패했습니다."),
+  REVIEW_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 수정이 실패했습니다."),
+  REVIEW_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 삭제가 실패했습니다."),
   REVIEW_TEXT_REQUIRED(HttpStatus.BAD_REQUEST, "수정할 내용은 필수입니다."),
   NOT_REVIEW_OWNER(HttpStatus.UNAUTHORIZED, "댓글 작성자만 수정할 수 있습니다."),
   SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 등록이 실패했습니다."),
-  NOT_REVIEW_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "댓글 작성자만 삭제할 수 있습니다.");
+  NOT_REVIEW_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "댓글 작성자만 삭제할 수 있습니다."),
+  REVIEW_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 댓글 조회에 실패했습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/UserException.java
+++ b/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/UserException.java
@@ -19,7 +19,8 @@ public enum UserException implements ExceptionType {
   EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 실패"),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 등록이 실패했습니다."),
   INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 ACCESSTOKEN입니다."),
-  INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 REFRESHTOKEN입니다.");
+  INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 REFRESHTOKEN입니다."),
+  NOT_ADMIN(HttpStatus.UNAUTHORIZED, "관리자만 게시글 등록이 가능합니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/hanyang/arttherapy/controller/ArtsController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/ArtsController.java
@@ -1,5 +1,6 @@
 package com.hanyang.arttherapy.controller;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,19 @@ public class ArtsController {
 
     Map<String, Object> result = artsService.getArtsByFilter(year, cohort, lastId);
     return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/years")
+  public ResponseEntity<Map<String, Object>> getAvailableYears() {
+    List<Integer> years = artsService.getAvailableYears();
+    return ResponseEntity.ok(Map.of("years", years));
+  }
+
+  @GetMapping("/cohorts")
+  public ResponseEntity<Map<String, Object>> getAvailableCohorts(
+      @RequestParam(required = false) Integer year) {
+    List<Integer> cohorts = artsService.getAvailableCohorts(year);
+    return ResponseEntity.ok(Map.of("cohorts", cohorts));
   }
 
   // 작품 상세 조회

--- a/src/main/java/com/hanyang/arttherapy/controller/NoticesController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/NoticesController.java
@@ -1,0 +1,49 @@
+package com.hanyang.arttherapy.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import com.hanyang.arttherapy.domain.enums.NoticeCategory;
+import com.hanyang.arttherapy.dto.request.NoticeRequestDto;
+import com.hanyang.arttherapy.dto.response.noticeResponse.CommonDataResponse;
+import com.hanyang.arttherapy.dto.response.noticeResponse.NoticeDetailResponseDto;
+import com.hanyang.arttherapy.dto.response.noticeResponse.NoticeListResponseDto;
+import com.hanyang.arttherapy.service.NoticesService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticesController {
+
+  private final NoticesService noticesService;
+
+  // 전체 조회
+  @GetMapping
+  public NoticeListResponseDto getNotices(
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) NoticeCategory category,
+      @RequestParam(defaultValue = "0") int page) {
+    return noticesService.getNotices(keyword, category, page);
+  }
+
+  // 상세 조회
+  @GetMapping("/{noticeNo}")
+  public NoticeDetailResponseDto getNoticeDetail(@PathVariable Long noticeNo) {
+    return noticesService.getNoticeDetail(noticeNo);
+  }
+
+  @PostMapping
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<CommonDataResponse<NoticeDetailResponseDto>> createNotice(
+      @RequestBody @Valid NoticeRequestDto requestDto) {
+    NoticeDetailResponseDto response = noticesService.createNotice(requestDto);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(new CommonDataResponse<>("게시글 등록이 완료되었습니다.", response));
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/controller/ReviewController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/ReviewController.java
@@ -2,14 +2,16 @@ package com.hanyang.arttherapy.controller;
 
 import java.util.Map;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.hanyang.arttherapy.dto.request.ReviewRequestDto;
 import com.hanyang.arttherapy.dto.response.ReviewResponseDto;
+import com.hanyang.arttherapy.dto.response.noticeResponse.CommonDataResponse;
+import com.hanyang.arttherapy.dto.response.userResponse.CommonMessageResponse;
 import com.hanyang.arttherapy.service.ReviewService;
 
 import lombok.RequiredArgsConstructor;
@@ -23,36 +25,36 @@ public class ReviewController {
 
   // 리뷰 조회
   @GetMapping
-  public ResponseEntity<Page<ReviewResponseDto>> getReviews(
-      @PathVariable Long artsNo, Pageable pageable) {
+  public ResponseEntity<Map<String, Object>> getReviews(
+      @PathVariable Long artsNo, @PageableDefault(size = 5) Pageable pageable) {
     return ResponseEntity.ok(reviewService.getReviews(artsNo, pageable));
   }
 
   // 리뷰 생성
   @PostMapping
-  public ResponseEntity<ReviewResponseDto> createReview(
+  public ResponseEntity<CommonDataResponse<ReviewResponseDto>> createReview(
       @PathVariable Long artsNo, @RequestBody ReviewRequestDto reviewRequestDto) {
 
     ReviewResponseDto responseDto = reviewService.createReview(artsNo, reviewRequestDto);
-    return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(new CommonDataResponse<>("댓글 등록이 완료되었습니다", responseDto));
   }
 
   // 리뷰 수정
   @PatchMapping("/{reviewNo}")
-  public ResponseEntity<ReviewResponseDto> updateReview(
+  public ResponseEntity<CommonDataResponse<ReviewResponseDto>> updateReview(
       @PathVariable Long reviewNo, @RequestBody ReviewRequestDto reviewRequestDto) {
+
     ReviewResponseDto responseDto =
         reviewService.patchReview(
             reviewNo, reviewRequestDto.reviewText(), reviewRequestDto.filesNo());
-    return ResponseEntity.ok(responseDto);
+    return ResponseEntity.ok(new CommonDataResponse<>("댓글 수정이 완료되었습니다", responseDto));
   }
 
   // 리뷰 삭제
   @DeleteMapping("/{reviewNo}")
-  public ResponseEntity<Map<String, String>> deleteReview(@PathVariable Long reviewNo) {
+  public ResponseEntity<CommonMessageResponse> deleteReview(@PathVariable Long reviewNo) {
     reviewService.deleteReview(reviewNo);
-
-    Map<String, String> response = Map.of("message", "댓글이 성공적으로 삭제되었습니다.");
-    return ResponseEntity.ok(response);
+    return ResponseEntity.ok(new CommonMessageResponse("댓글 삭제가 완료되었습니다."));
   }
 }

--- a/src/main/java/com/hanyang/arttherapy/domain/NoticeFiles.java
+++ b/src/main/java/com/hanyang/arttherapy/domain/NoticeFiles.java
@@ -1,0 +1,32 @@
+package com.hanyang.arttherapy.domain;
+
+import jakarta.persistence.*;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeFiles {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long noticeFileNo;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "noticeNo", nullable = false)
+  private Notices notice;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "filesNo", nullable = false)
+  private Files file;
+
+  @Builder
+  public NoticeFiles(Notices notice, Files file) {
+    this.notice = notice;
+    this.file = file;
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/domain/Notices.java
+++ b/src/main/java/com/hanyang/arttherapy/domain/Notices.java
@@ -1,0 +1,62 @@
+package com.hanyang.arttherapy.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import com.hanyang.arttherapy.common.entity.BaseEntity;
+import com.hanyang.arttherapy.domain.enums.NoticeCategory;
+
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notices extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long noticesNo;
+
+  @ManyToOne
+  @JoinColumn(name = "user_no")
+  private Users user;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NoticeCategory category;
+
+  @Column(nullable = false)
+  private Integer viewCount = 0;
+
+  @Column private LocalDateTime periodStart;
+
+  @Column private LocalDateTime periodEnd;
+
+  @Builder
+  public Notices(
+      String title,
+      String content,
+      Users user,
+      NoticeCategory category,
+      LocalDateTime periodStart,
+      LocalDateTime periodEnd) {
+    this.title = title;
+    this.content = content;
+    this.user = user;
+    this.category = category;
+    this.periodStart = periodStart;
+    this.periodEnd = periodEnd;
+    this.viewCount = 0;
+  }
+
+  public void increaseViewCount() {
+    this.viewCount++;
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/domain/enums/FileExtension.java
+++ b/src/main/java/com/hanyang/arttherapy/domain/enums/FileExtension.java
@@ -7,7 +7,7 @@ enum FileExtension {
   IMAGE(
       "jpg", "jpeg", "png", "gif", "bmp", "tiff", "tif", "webp", "svg", "heif", "heic", "raw",
       "nef", "cr2", "arw", "dng", "orf", "sr2", "ico", "eps", "psd"),
-  DOCUMENT("pdf", "docx", "xlsx", "pptx", "txt", "rtf", "odt"),
+  DOCUMENT("pdf", "docx", "xlsx", "pptx", "txt", "rtf", "odt", "hwp", "hwpx", "ppt", "doc", "xls"),
   VIDEO("mp4", "mkv", "avi", "mov", "flv", "webm"),
   AUDIO("mp3", "wav", "ogg", "flac", "aac", "m4a"),
   ARCHIVE("zip", "rar", "tar", "7z", "gzip");

--- a/src/main/java/com/hanyang/arttherapy/domain/enums/NoticeCategory.java
+++ b/src/main/java/com/hanyang/arttherapy/domain/enums/NoticeCategory.java
@@ -1,0 +1,9 @@
+package com.hanyang.arttherapy.domain.enums;
+
+public enum NoticeCategory {
+  PRACTICE,
+  RECRUIT,
+  GENERAL,
+  EXHIBITION,
+  ACADEMIC
+}

--- a/src/main/java/com/hanyang/arttherapy/dto/request/NoticeRequestDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/request/NoticeRequestDto.java
@@ -1,0 +1,14 @@
+package com.hanyang.arttherapy.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.hanyang.arttherapy.domain.enums.NoticeCategory;
+
+public record NoticeRequestDto(
+    String title,
+    NoticeCategory category,
+    LocalDate periodStart,
+    LocalDate periodEnd,
+    String content,
+    List<Long> filesNo) {}

--- a/src/main/java/com/hanyang/arttherapy/dto/response/ArtsListResponseDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/ArtsListResponseDto.java
@@ -31,11 +31,11 @@ public record ArtsListResponseDto(
         arts.getArtsNo(),
         arts.getArtName(),
         coDescription,
-        new FileResponseDto(file.getUrl()),
+        new FileResponseDto(file.getName(), file.getUrl()),
         artistDtos);
   }
 
-  public record FileResponseDto(String url) {}
+  public record FileResponseDto(String name, String url) {}
 
   public record ArtistResponseDto(String artistName, int cohort, String description) {}
 }

--- a/src/main/java/com/hanyang/arttherapy/dto/response/ReviewResponseDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/ReviewResponseDto.java
@@ -1,6 +1,12 @@
 package com.hanyang.arttherapy.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record ReviewResponseDto(
-    Long reviewNo, String reviewText, String userName, Long userNo, List<FileResponseDto> files) {}
+    Long reviewNo,
+    String reviewText,
+    String userName,
+    Long userNo,
+    List<FileResponseDto> files,
+    LocalDateTime createdAt) {}

--- a/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/AdjacentNoticeDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/AdjacentNoticeDto.java
@@ -1,0 +1,3 @@
+package com.hanyang.arttherapy.dto.response.noticeResponse;
+
+public record AdjacentNoticeDto(Long noticeNo, String title, String createdAt) {}

--- a/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/CommonDataResponse.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/CommonDataResponse.java
@@ -1,0 +1,3 @@
+package com.hanyang.arttherapy.dto.response.noticeResponse;
+
+public record CommonDataResponse<T>(String message, T data) {}

--- a/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/NoticeDetailResponseDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/NoticeDetailResponseDto.java
@@ -1,0 +1,20 @@
+package com.hanyang.arttherapy.dto.response.noticeResponse;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.hanyang.arttherapy.dto.response.FileResponseDto;
+
+public record NoticeDetailResponseDto(
+    Long noticeNo,
+    String title,
+    String category,
+    LocalDateTime createdAt,
+    LocalDate periodStart,
+    LocalDate periodEnd,
+    int viewCount,
+    String content,
+    List<FileResponseDto> files,
+    AdjacentNoticeDto previous,
+    AdjacentNoticeDto next) {}

--- a/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/NoticeListResponseDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/NoticeListResponseDto.java
@@ -1,0 +1,11 @@
+package com.hanyang.arttherapy.dto.response.noticeResponse;
+
+import java.util.List;
+
+public record NoticeListResponseDto(
+    List<NoticeResponseDto> content,
+    int page,
+    int size,
+    int totalElements,
+    int totalPages,
+    boolean isLast) {}

--- a/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/NoticeResponseDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/noticeResponse/NoticeResponseDto.java
@@ -1,0 +1,11 @@
+package com.hanyang.arttherapy.dto.response.noticeResponse;
+
+import java.time.LocalDateTime;
+
+public record NoticeResponseDto(
+    Long noticeNo,
+    String category,
+    String title,
+    boolean hasFile,
+    int viewCount,
+    LocalDateTime createdAt) {}

--- a/src/main/java/com/hanyang/arttherapy/repository/ArtArtistRelRepository.java
+++ b/src/main/java/com/hanyang/arttherapy/repository/ArtArtistRelRepository.java
@@ -18,13 +18,22 @@ public interface ArtArtistRelRepository extends JpaRepository<ArtArtistRel, Long
 
   @Query(
       """
-  SELECT ar
-  FROM ArtArtistRel ar
-  JOIN FETCH ar.artists
-  WHERE ar.arts.artsNo IN :artsNos
-""")
+      SELECT ar
+      FROM ArtArtistRel ar
+      JOIN FETCH ar.artists
+      WHERE ar.arts.artsNo IN :artsNos
+    """)
   List<ArtArtistRel> findWithArtistsByArtsNoIn(@Param("artsNos") List<Long> artsNos);
 
   // 관리자 작품
   void deleteByArts(Arts arts);
+
+  @Query(
+      """
+  SELECT DISTINCT r.artists.cohort
+  FROM ArtArtistRel r
+  WHERE r.arts.galleries.galleriesNo = :galleriesNo
+  ORDER BY r.artists.cohort ASC
+""")
+  List<Integer> findDistinctCohortsByGalleriesNo(@Param("galleriesNo") Long galleriesNo);
 }

--- a/src/main/java/com/hanyang/arttherapy/repository/NoticeFilesRepository.java
+++ b/src/main/java/com/hanyang/arttherapy/repository/NoticeFilesRepository.java
@@ -1,0 +1,17 @@
+package com.hanyang.arttherapy.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hanyang.arttherapy.domain.NoticeFiles;
+import com.hanyang.arttherapy.domain.Notices;
+
+public interface NoticeFilesRepository extends JpaRepository<NoticeFiles, Long> {
+
+  // 특정 공지에 연결된 파일 존재 여부
+  boolean existsByNotice(Notices notice);
+
+  // 첨부파일 목록 조회
+  List<NoticeFiles> findAllByNotice(Notices notice);
+}

--- a/src/main/java/com/hanyang/arttherapy/repository/NoticesRepository.java
+++ b/src/main/java/com/hanyang/arttherapy/repository/NoticesRepository.java
@@ -1,0 +1,39 @@
+package com.hanyang.arttherapy.repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.hanyang.arttherapy.domain.Notices;
+import com.hanyang.arttherapy.domain.enums.NoticeCategory;
+
+public interface NoticesRepository extends JpaRepository<Notices, Long> {
+
+  // 카테고리, 검색, 카테고리 + 검색
+  @Query(
+      "SELECT n FROM Notices n "
+          + "WHERE (:category IS NULL OR n.category = :category) "
+          + "AND (:keyword IS NULL OR n.title LIKE %:keyword% OR n.content LIKE %:keyword%)")
+  Page<Notices> findAllBySearch(
+      @Param("category") NoticeCategory category,
+      @Param("keyword") String keyword,
+      Pageable pageable);
+
+  // 단건 조회
+  boolean existsByNoticesNo(Long noticesNo);
+
+  Optional<Notices> findByNoticesNo(Long noticesNo);
+
+  // 이전글
+  @Query("SELECT n FROM Notices n WHERE n.createdAt < :createdAt ORDER BY n.createdAt DESC")
+  Page<Notices> findPreviousNotice(@Param("createdAt") LocalDateTime createdAt, Pageable pageable);
+
+  // 다음글
+  @Query("SELECT n FROM Notices n WHERE n.createdAt > :createdAt ORDER BY n.createdAt ASC")
+  Page<Notices> findNextNotice(@Param("createdAt") LocalDateTime createdAt, Pageable pageable);
+}

--- a/src/main/java/com/hanyang/arttherapy/service/NoticesService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/NoticesService.java
@@ -1,0 +1,208 @@
+package com.hanyang.arttherapy.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hanyang.arttherapy.common.exception.CustomException;
+import com.hanyang.arttherapy.common.exception.exceptionType.FileSystemExceptionType;
+import com.hanyang.arttherapy.common.exception.exceptionType.NoticeException;
+import com.hanyang.arttherapy.common.exception.exceptionType.UserException;
+import com.hanyang.arttherapy.domain.Files;
+import com.hanyang.arttherapy.domain.NoticeFiles;
+import com.hanyang.arttherapy.domain.Notices;
+import com.hanyang.arttherapy.domain.Users;
+import com.hanyang.arttherapy.domain.enums.NoticeCategory;
+import com.hanyang.arttherapy.domain.enums.Role;
+import com.hanyang.arttherapy.dto.request.NoticeRequestDto;
+import com.hanyang.arttherapy.dto.response.FileResponseDto;
+import com.hanyang.arttherapy.dto.response.noticeResponse.AdjacentNoticeDto;
+import com.hanyang.arttherapy.dto.response.noticeResponse.NoticeDetailResponseDto;
+import com.hanyang.arttherapy.dto.response.noticeResponse.NoticeListResponseDto;
+import com.hanyang.arttherapy.dto.response.noticeResponse.NoticeResponseDto;
+import com.hanyang.arttherapy.repository.FilesRepository;
+import com.hanyang.arttherapy.repository.NoticeFilesRepository;
+import com.hanyang.arttherapy.repository.NoticesRepository;
+import com.hanyang.arttherapy.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoticesService {
+  private final NoticesRepository noticesRepository;
+  private final NoticeFilesRepository noticeFilesRepository;
+  private final UserRepository userRepository;
+  private final FilesRepository filesRepository;
+
+  // 전체 조회
+  public NoticeListResponseDto getNotices(String keyword, NoticeCategory category, int page) {
+    Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+    Page<Notices> noticesPage = noticesRepository.findAllBySearch(category, keyword, pageable);
+
+    List<NoticeResponseDto> content =
+        noticesPage.getContent().stream()
+            .map(
+                notice -> {
+                  boolean hasFile = noticeFilesRepository.existsByNotice(notice);
+                  return new NoticeResponseDto(
+                      notice.getNoticesNo(),
+                      notice.getCategory().name(),
+                      notice.getTitle(),
+                      hasFile,
+                      notice.getViewCount(),
+                      notice.getCreatedAt());
+                })
+            .toList();
+
+    return new NoticeListResponseDto(
+        content,
+        noticesPage.getNumber(),
+        noticesPage.getSize(),
+        (int) noticesPage.getTotalElements(),
+        noticesPage.getTotalPages(),
+        noticesPage.isLast());
+  }
+
+  // 상세 조회
+  public NoticeDetailResponseDto getNoticeDetail(Long noticeNo) {
+    // 1. 공지 단건 조회
+    Notices notice =
+        noticesRepository
+            .findByNoticesNo(noticeNo)
+            .orElseThrow(() -> new CustomException(NoticeException.NOTICE_NOT_FOUND));
+
+    // 2. 조회수 증가
+    notice.increaseViewCount();
+    // 별도 save() 불필요 (JPA 더티 체킹)
+
+    // 3. 첨부파일 조회
+    List<FileResponseDto> files =
+        noticeFilesRepository.findAllByNotice(notice).stream()
+            .map(
+                nf -> {
+                  Files file = nf.getFile();
+                  return FileResponseDto.of(file, file.getUrl());
+                })
+            .toList();
+
+    // 4. 이전글 조회
+    Page<Notices> prevPage =
+        noticesRepository.findPreviousNotice(notice.getCreatedAt(), PageRequest.of(0, 1));
+    AdjacentNoticeDto previous =
+        prevPage.isEmpty() ? null : mapToAdjacent(prevPage.getContent().get(0));
+
+    // 5. 다음글 조회
+    Page<Notices> nextPage =
+        noticesRepository.findNextNotice(notice.getCreatedAt(), PageRequest.of(0, 1));
+    AdjacentNoticeDto next =
+        nextPage.isEmpty() ? null : mapToAdjacent(nextPage.getContent().get(0));
+
+    // 6. 응답 조립
+    return new NoticeDetailResponseDto(
+        notice.getNoticesNo(),
+        notice.getTitle(),
+        notice.getCategory().name(),
+        notice.getCreatedAt(),
+        notice.getPeriodStart().toLocalDate(),
+        notice.getPeriodEnd().toLocalDate(),
+        notice.getViewCount(),
+        notice.getContent(),
+        files,
+        previous,
+        next);
+  }
+
+  // 게시글 등록
+  public NoticeDetailResponseDto createNotice(NoticeRequestDto dto) {
+    // 1. 로그인 유저 조회
+    Users currentUser = getCurrentUser();
+    if (!currentUser.getRole().equals(Role.ADMIN)) {
+      throw new CustomException(UserException.NOT_ADMIN);
+    }
+
+    // 2. 공지 저장
+    Notices notice =
+        Notices.builder()
+            .title(dto.title())
+            .category(dto.category())
+            .periodStart(dto.periodStart() != null ? dto.periodStart().atStartOfDay() : null)
+            .periodEnd(dto.periodEnd() != null ? dto.periodEnd().atStartOfDay() : null)
+            .content(dto.content())
+            .user(currentUser)
+            .build();
+    noticesRepository.save(notice);
+
+    // 3. 첨부파일 처리
+    List<FileResponseDto> fileResponses = List.of();
+    if (dto.filesNo() != null) {
+      fileResponses =
+          dto.filesNo().stream()
+              .map(
+                  fileNo -> {
+                    Files file =
+                        filesRepository
+                            .findById(fileNo)
+                            .orElseThrow(
+                                () -> new CustomException(FileSystemExceptionType.FILE_NOT_FOUND));
+                    file.activateFile();
+                    filesRepository.save(file);
+
+                    NoticeFiles mapping = NoticeFiles.builder().notice(notice).file(file).build();
+                    noticeFilesRepository.save(mapping);
+
+                    return FileResponseDto.of(file, file.getUrl());
+                  })
+              .toList();
+    }
+
+    // 4. 이전글/다음글 조회 (createdAt 기준)
+    Page<Notices> prevPage =
+        noticesRepository.findPreviousNotice(notice.getCreatedAt(), PageRequest.of(0, 1));
+    AdjacentNoticeDto previous =
+        prevPage.isEmpty() ? null : mapToAdjacent(prevPage.getContent().get(0));
+
+    Page<Notices> nextPage =
+        noticesRepository.findNextNotice(notice.getCreatedAt(), PageRequest.of(0, 1));
+    AdjacentNoticeDto next =
+        nextPage.isEmpty() ? null : mapToAdjacent(nextPage.getContent().get(0));
+
+    // 5. 최종 응답 조립
+    return new NoticeDetailResponseDto(
+        notice.getNoticesNo(),
+        notice.getTitle(),
+        notice.getCategory().name(),
+        notice.getCreatedAt(),
+        notice.getPeriodStart() != null ? notice.getPeriodStart().toLocalDate() : null,
+        notice.getPeriodEnd() != null ? notice.getPeriodEnd().toLocalDate() : null,
+        notice.getViewCount(),
+        notice.getContent(),
+        fileResponses,
+        previous,
+        next);
+  }
+
+  private Users getCurrentUser() {
+    Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    if (!(principal instanceof Users user)) {
+      throw new CustomException(UserException.USER_NOT_FOUND);
+    }
+    return user;
+  }
+
+  // 내부 변환 함수
+  private AdjacentNoticeDto mapToAdjacent(Notices n) {
+    return new AdjacentNoticeDto(n.getNoticesNo(), n.getTitle(), n.getCreatedAt().toString());
+  }
+}


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
- closed #103 
- closed #97 
- closed #98 
- closed #99 

## :writing_hand: Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 작품 전체 조회시 연도 및 기수 필터링 목록 추가
- 공지게시판 전체 조회 기능추가
- 공지게시판 상세 조회 기능 추가
- 공지게시판 관리자만 게시글 등록 기능 추가
- 댓글 조회 페이지네이션 수정

## :white_check_mark: Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/user-attachments/assets/03c63fa6-cff5-4fb4-b12f-a2d47d21e976)
![image](https://github.com/user-attachments/assets/be390b4d-aaf0-4bee-928b-649502ecbae5)
![image](https://github.com/user-attachments/assets/7b38866b-6864-45ce-a224-e7c86cded882)
![image](https://github.com/user-attachments/assets/dd7e8235-c29d-4676-83bc-08df5c3daed0)
![image](https://github.com/user-attachments/assets/15fd5600-80af-4d2a-96c0-8b3356b5e6e2)
![스크린샷 2025-05-27 102608](https://github.com/user-attachments/assets/d96d33f8-1044-4d8e-bf9b-81d35b426f99)
![스크린샷 2025-05-27 102615](https://github.com/user-attachments/assets/0fa6efbd-38f7-495d-9d6a-6eef24c80cdf)
![image](https://github.com/user-attachments/assets/1b059e8e-566e-490f-9043-071edbafae26)

