### PR TITLE
[FEAT] 회원 전체 및 상세조회, 이름 조회 및 수정

### DIFF
--- a/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/UserException.java
+++ b/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/UserException.java
@@ -19,7 +19,8 @@ public enum UserException implements ExceptionType {
   EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 실패"),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 등록이 실패했습니다."),
   INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 ACCESSTOKEN입니다."),
-  INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 REFRESHTOKEN입니다.");
+  INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 REFRESHTOKEN입니다."),
+  USER_HISTORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 회원의 가입 이력을 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/hanyang/arttherapy/controller/AdminUserController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/AdminUserController.java
@@ -1,0 +1,44 @@
+package com.hanyang.arttherapy.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import com.hanyang.arttherapy.dto.request.userRequest.UserRequestDto;
+import com.hanyang.arttherapy.dto.response.userResponse.CommonMessageResponse;
+import com.hanyang.arttherapy.dto.response.userResponse.UserDetailDto;
+import com.hanyang.arttherapy.service.AdminUserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/users")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUserController {
+
+  private final AdminUserService adminUserService;
+
+  // 전체 조회 또는 이름 검색 조회
+  @GetMapping
+  public ResponseEntity<Map<String, Object>> getUsers(
+      @RequestParam(value = "name", required = false) String name, Long lastId) {
+    return ResponseEntity.ok(adminUserService.getUsers(name, lastId));
+  }
+
+  // 회원 상세 조회
+  @GetMapping("/{userNo}")
+  public ResponseEntity<UserDetailDto> getUserDetail(@PathVariable Long userNo) {
+    return ResponseEntity.ok(adminUserService.getUserDetail(userNo));
+  }
+
+  // 회원 정보 수정
+  @PatchMapping("/{userNo}")
+  public ResponseEntity<CommonMessageResponse> updateUser(
+      @PathVariable Long userNo, @RequestBody UserRequestDto requestDto) {
+    adminUserService.updateUser(userNo, requestDto);
+    return ResponseEntity.ok(new CommonMessageResponse("회원 정보가 수정되었습니다."));
+  }
+}

--- a/src/main/java/com/hanyang/arttherapy/domain/Users.java
+++ b/src/main/java/com/hanyang/arttherapy/domain/Users.java
@@ -54,4 +54,13 @@ public class Users {
 
     this.userStatus = UserStatus.ACTIVE; // userState를 기본값 ACTIVE로 설정
   }
+
+  public void updateInfo(
+      String email, String userName, String studentNo, Role role, UserStatus userStatus) {
+    this.email = email;
+    this.userName = userName;
+    this.studentNo = studentNo;
+    this.role = role;
+    this.userStatus = userStatus;
+  }
 }

--- a/src/main/java/com/hanyang/arttherapy/dto/request/userRequest/UserRequestDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/request/userRequest/UserRequestDto.java
@@ -1,0 +1,7 @@
+package com.hanyang.arttherapy.dto.request.userRequest;
+
+import com.hanyang.arttherapy.domain.enums.Role;
+import com.hanyang.arttherapy.domain.enums.UserStatus;
+
+public record UserRequestDto(
+    String email, String userName, String studentNo, Role role, UserStatus userStatus) {}

--- a/src/main/java/com/hanyang/arttherapy/dto/response/userResponse/UserDetailDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/userResponse/UserDetailDto.java
@@ -1,0 +1,20 @@
+package com.hanyang.arttherapy.dto.response.userResponse;
+
+import java.sql.Timestamp;
+
+import com.hanyang.arttherapy.domain.enums.Role;
+import com.hanyang.arttherapy.domain.enums.UserStatus;
+
+public record UserDetailDto(
+    Long userNo,
+    String userId,
+    String passWord,
+    String email,
+    String userName,
+    String studentNo,
+    Role role,
+    UserStatus userStatus,
+    Timestamp signinTimestamp,
+    Timestamp signoutTimestamp,
+    Timestamp bannedTimestamp,
+    String cause) {}

--- a/src/main/java/com/hanyang/arttherapy/dto/response/userResponse/UserDto.java
+++ b/src/main/java/com/hanyang/arttherapy/dto/response/userResponse/UserDto.java
@@ -1,0 +1,7 @@
+package com.hanyang.arttherapy.dto.response.userResponse;
+
+import com.hanyang.arttherapy.domain.enums.Role;
+import com.hanyang.arttherapy.domain.enums.UserStatus;
+
+public record UserDto(
+    Long userNo, String userName, String studentNo, Role role, UserStatus userStatus) {}

--- a/src/main/java/com/hanyang/arttherapy/repository/UserRepository.java
+++ b/src/main/java/com/hanyang/arttherapy/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.hanyang.arttherapy.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,9 @@ public interface UserRepository
   Optional<Users> findByUserId(String userId);
 
   Optional<Users> findByUserNo(Long userNo);
+
+  List<Users> findTop10ByUserNoLessThanOrderByUserNoDesc(Long lastId);
+
+  List<Users> findTop10ByUserNameContainingAndUserNoLessThanOrderByUserNoDesc(
+      String name, Long lastId);
 }

--- a/src/main/java/com/hanyang/arttherapy/service/AdminUserService.java
+++ b/src/main/java/com/hanyang/arttherapy/service/AdminUserService.java
@@ -1,0 +1,99 @@
+package com.hanyang.arttherapy.service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hanyang.arttherapy.common.exception.CustomException;
+import com.hanyang.arttherapy.common.exception.exceptionType.UserException;
+import com.hanyang.arttherapy.domain.Users;
+import com.hanyang.arttherapy.domain.UsersHistory;
+import com.hanyang.arttherapy.dto.request.userRequest.UserRequestDto;
+import com.hanyang.arttherapy.dto.response.userResponse.UserDetailDto;
+import com.hanyang.arttherapy.dto.response.userResponse.UserDto;
+import com.hanyang.arttherapy.repository.UserRepository;
+import com.hanyang.arttherapy.repository.UsersHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserService {
+
+  private final UserRepository userRepository;
+  private final UsersHistoryRepository usersHistoryRepository;
+
+  // 전체 조회 또는 이름 검색 조회 (무한스크롤)
+  public Map<String, Object> getUsers(String name, Long lastId) {
+    Long cursor = (lastId == null) ? Long.MAX_VALUE : lastId;
+
+    List<Users> users =
+        (name != null && !name.isBlank())
+            ? userRepository.findTop10ByUserNameContainingAndUserNoLessThanOrderByUserNoDesc(
+                name, cursor)
+            : userRepository.findTop10ByUserNoLessThanOrderByUserNoDesc(cursor);
+
+    List<UserDto> content = users.stream().map(this::convertToDto).toList();
+
+    boolean hasNext = content.size() == 10;
+
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("content", content);
+    response.put("lastId", !content.isEmpty() ? content.get(content.size() - 1).userNo() : null);
+    response.put("hasNext", hasNext);
+    return response;
+  }
+
+  public UserDetailDto getUserDetail(Long userNo) {
+    Users user =
+        userRepository
+            .findByUserNo(userNo)
+            .orElseThrow(() -> new CustomException(UserException.USER_NOT_FOUND));
+
+    UsersHistory history =
+        usersHistoryRepository
+            .findByUser_UserNo(userNo)
+            .orElseThrow(() -> new CustomException(UserException.USER_HISTORY_NOT_FOUND));
+
+    return new UserDetailDto(
+        user.getUserNo(),
+        user.getUserId(),
+        user.getPassword(),
+        user.getEmail(),
+        user.getUserName(),
+        user.getStudentNo(),
+        user.getRole(),
+        user.getUserStatus(),
+        history.getSigninTimestamp(),
+        history.getSignoutTimestamp(),
+        history.getBannedTimestamp(),
+        history.getCause());
+  }
+
+  public void updateUser(Long userNo, UserRequestDto request) {
+    Users user =
+        userRepository
+            .findByUserNo(userNo)
+            .orElseThrow(() -> new CustomException(UserException.USER_NOT_FOUND));
+
+    user.updateInfo(
+        request.email(),
+        request.userName(),
+        request.studentNo(),
+        request.role(),
+        request.userStatus());
+  }
+
+  private UserDto convertToDto(Users user) {
+    return new UserDto(
+        user.getUserNo(),
+        user.getUserName(),
+        user.getStudentNo(),
+        user.getRole(),
+        user.getUserStatus());
+  }
+}


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
- closed #123 
- closed #124 
- closed #125 
- closed #126 

## :writing_hand: Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 관리자 페이지내 회원 정보 전체 조회
- 관리자 페이지내 회원 이름 검색 및 조회
- 관리자 페이지내 회원 정보 상세 조회
- 관리자 페이지내 회원 정보 수정

## :white_check_mark: Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![스크린샷 2025-05-30 221510](https://github.com/user-attachments/assets/7d16ea8a-f28d-4c18-b6f2-299927a0ba1b)
![스크린샷 2025-05-30 221536](https://github.com/user-attachments/assets/d3af12fb-51a5-43b6-a04d-52482bfd373d)
![스크린샷 2025-05-30 221519](https://github.com/user-attachments/assets/68744232-487a-4d13-8bf8-664f81218aad)
![스크린샷 2025-05-30 221553](https://github.com/user-attachments/assets/75ef23d4-22ee-418d-9e0a-b63ca4aa19ab)
