### PR TITLE
[FEAT] 관리자 회원 조회 페이지 로그인 및 관리자 권한 검증 로직 추가

### DIFF
--- a/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/UserException.java
+++ b/src/main/java/com/hanyang/arttherapy/common/exception/exceptionType/UserException.java
@@ -20,7 +20,9 @@ public enum UserException implements ExceptionType {
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 등록이 실패했습니다."),
   INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 ACCESSTOKEN입니다."),
   INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 REFRESHTOKEN입니다."),
-  USER_HISTORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 회원의 가입 이력을 찾을 수 없습니다.");
+  USER_HISTORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 회원의 가입 이력을 찾을 수 없습니다."),
+  NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
+  UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/hanyang/arttherapy/controller/AdminUserController.java
+++ b/src/main/java/com/hanyang/arttherapy/controller/AdminUserController.java
@@ -38,7 +38,7 @@ public class AdminUserController {
   @PatchMapping("/{userNo}")
   public ResponseEntity<CommonMessageResponse> updateUser(
       @PathVariable Long userNo, @RequestBody UserRequestDto requestDto) {
-    adminUserService.updateUser(userNo, requestDto);
-    return ResponseEntity.ok(new CommonMessageResponse("회원 정보가 수정되었습니다."));
+    String message = adminUserService.updateUser(userNo, requestDto);
+    return ResponseEntity.ok(new CommonMessageResponse(message));
   }
 }


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
-closed #139
## :writing_hand: Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 관리자의 회원 조회 페이지에서 로그인 및 관리자 권한 검증 로직 추가
## :white_check_mark: Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 